### PR TITLE
Add equipment editing and mirroring

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,15 @@
 
     <h2>Hands</h2>
     <div id="hands">
-        <div>Left Hand: <input type="text" id="leftHand" placeholder="empty"></div>
-        <div>Right Hand: <input type="text" id="rightHand" placeholder="empty"></div>
+        <div>Left Hand: <input type="text" id="leftHand" placeholder="empty"> <button id="editLeft">Edit</button></div>
+        <div>Right Hand: <input type="text" id="rightHand" placeholder="empty"> <button id="editRight">Edit</button></div>
+    </div>
+    <button id="mirrorHand" style="display:none;">Mirror Item</button>
+
+    <div id="equipChooser" style="display:none;">
+        <p id="equipPrompt"></p>
+        <div id="equipOptions"></div>
+        <button id="equipCancel">Cancel</button>
     </div>
 
     <h2>Actions</h2>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,26 @@ const attackLeftBtn = document.getElementById('attackLeft');
 const attackRightBtn = document.getElementById('attackRight');
 const actionCountSpan = document.getElementById('actionCount');
 const interactionCountSpan = document.getElementById('interactionCount');
+const leftHandInput = document.getElementById('leftHand');
+const rightHandInput = document.getElementById('rightHand');
+const editLeftBtn = document.getElementById('editLeft');
+const editRightBtn = document.getElementById('editRight');
+const mirrorBtn = document.getElementById('mirrorHand');
+const equipChooser = document.getElementById('equipChooser');
+const equipPrompt = document.getElementById('equipPrompt');
+const equipOptionsDiv = document.getElementById('equipOptions');
+const equipCancel = document.getElementById('equipCancel');
+
+let currentHand = null;
+const equipmentChoices = [
+    'lighting source',
+    'shield',
+    'spellcasting focus',
+    'two-handed weapon',
+    'one-handed weapon',
+    'another item',
+    'empty'
+];
 
 let actions = 0;
 let freeInteraction = 0;
@@ -25,6 +45,7 @@ startTurnBtn.addEventListener('click', () => {
     freeInteraction = 1;
     updateCounts();
     startTurnBtn.disabled = true;
+    checkHands();
 });
 
 endTurnBtn.addEventListener('click', () => {
@@ -35,6 +56,7 @@ endTurnBtn.addEventListener('click', () => {
     attackBtn.disabled = true;
     utilizeBtn.disabled = true;
     freeInteractBtn.disabled = true;
+    checkHands();
 });
 
 function updateCounts() {
@@ -43,6 +65,47 @@ function updateCounts() {
     attackBtn.disabled = actions === 0;
     utilizeBtn.disabled = actions === 0;
     freeInteractBtn.disabled = freeInteraction === 0;
+}
+
+function checkHands() {
+    const leftEmpty = leftHandInput.value === '';
+    const rightEmpty = rightHandInput.value === '';
+    mirrorBtn.style.display = (leftEmpty !== rightEmpty) ? 'inline-block' : 'none';
+}
+
+function editHand(handId) {
+    currentHand = handId;
+    equipPrompt.textContent = `Choose equipment for your ${handId.replace('Hand', '')} hand:`;
+    equipOptionsDiv.innerHTML = '';
+    equipmentChoices.forEach(opt => {
+        const btn = document.createElement('button');
+        btn.textContent = opt;
+        btn.addEventListener('click', () => applyEquipment(opt));
+        equipOptionsDiv.appendChild(btn);
+    });
+    equipChooser.style.display = 'block';
+}
+
+function applyEquipment(choice) {
+    if (!currentHand) return;
+    const hand = document.getElementById(currentHand);
+    const current = hand.value || 'empty';
+    const newItem = choice === 'empty' ? '' : choice;
+    const wasShield = current === 'shield';
+    const isShield = newItem === 'shield';
+    if (wasShield !== isShield) {
+        if (actions > 0) {
+            actions -= 1;
+            updateCounts();
+        } else {
+            alert('No actions left to equip or unequip a shield.');
+            return;
+        }
+    }
+    hand.value = newItem;
+    equipChooser.style.display = 'none';
+    currentHand = null;
+    checkHands();
 }
 
 attackBtn.addEventListener('click', () => {
@@ -59,6 +122,7 @@ function handleAttack(handInput) {
     const equip = prompt(`You attacked with your ${handInput.replace('Hand', '')} hand holding '${current}'.\nWould you like to change what's equipped? If yes, type the new item. Leave blank to keep the same.`);
     if (equip !== null && equip !== '') {
         hand.value = equip;
+        checkHands();
     }
     const more = confirm('Do you have more attacks?');
     if (!more) {
@@ -84,3 +148,22 @@ freeInteractBtn.addEventListener('click', () => {
         alert('Free Interaction used.');
     }
 });
+
+editLeftBtn.addEventListener('click', () => editHand('leftHand'));
+editRightBtn.addEventListener('click', () => editHand('rightHand'));
+
+equipCancel.addEventListener('click', () => {
+    equipChooser.style.display = 'none';
+    currentHand = null;
+});
+
+mirrorBtn.addEventListener('click', () => {
+    if (leftHandInput.value && !rightHandInput.value) {
+        rightHandInput.value = leftHandInput.value;
+    } else if (rightHandInput.value && !leftHandInput.value) {
+        leftHandInput.value = rightHandInput.value;
+    }
+    checkHands();
+});
+
+checkHands();

--- a/style.css
+++ b/style.css
@@ -5,3 +5,18 @@ body {
 button {
     margin: 5px;
 }
+
+#mirrorHand {
+    margin-top: 5px;
+}
+
+#equipChooser {
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-top: 10px;
+}
+
+#equipOptions button {
+    display: block;
+    margin: 5px 0;
+}


### PR DESCRIPTION
## Summary
- add edit buttons and mirroring for hand equipment
- manage shield actions and track hands in JS
- introduce clickable equipment chooser
- minor style update for new button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684705a9458c8325bc2da759b4540eb2