### PR TITLE
Revise hand equip logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small web-based D&D combat tracker.
 
 ## Features
 
-- Editable left and right hand equipment fields with options for lighting source, shield, spellcasting focus, two-handed weapon, one-handed weapon and other items.
+- Equip or unequip items in each hand with options for item, environment, weapon and shield. The button shows "Equip" when the hand is empty or combat is off and "Unequip" when holding something in combat.
 - Button to mirror the item from one hand to the other whenever exactly one hand is empty.
 - Equipping or removing a shield consumes an action if any are available; otherwise the action is blocked.
 

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
 
     <h2>Hands</h2>
     <div id="hands">
-        <div>Left Hand: <input type="text" id="leftHand" placeholder="empty"> <button id="editLeft">Edit</button></div>
-        <div>Right Hand: <input type="text" id="rightHand" placeholder="empty"> <button id="editRight">Edit</button></div>
+        <div>Left Hand: <input type="text" id="leftHand" placeholder="empty"> <button id="editLeft">Equip</button></div>
+        <div>Right Hand: <input type="text" id="rightHand" placeholder="empty"> <button id="editRight">Equip</button></div>
     </div>
     <button id="mirrorHand" style="display:none;">Mirror Item</button>
 

--- a/script.js
+++ b/script.js
@@ -19,12 +19,10 @@ const equipmentOptions = document.getElementById('equipmentOptions');
 const cancelPopup = document.getElementById('cancelPopup');
 
 const optionList = [
-    'lighting source',
+    'item',
+    'environment',
+    'weapon',
     'shield',
-    'spellcasting focus',
-    'two-handed weapon',
-    'one-handed weapon',
-    'another item',
     'empty'
 ];
 
@@ -41,10 +39,25 @@ let actions = 0;
 let freeInteraction = 0;
 let inCombat = false;
 
+function updateEquipButtons() {
+    const states = [
+        {input: leftHandInput, btn: editLeftBtn},
+        {input: rightHandInput, btn: editRightBtn}
+    ];
+    states.forEach(({input, btn}) => {
+        if (inCombat && input.value) {
+            btn.textContent = 'Unequip';
+        } else {
+            btn.textContent = 'Equip';
+        }
+    });
+}
+
 combatToggle.addEventListener('change', () => {
     inCombat = combatToggle.checked;
     startTurnBtn.disabled = !inCombat;
     endTurnBtn.disabled = !inCombat;
+    updateEquipButtons();
 });
 
 startTurnBtn.addEventListener('click', () => {
@@ -78,12 +91,32 @@ function checkHands() {
     const leftEmpty = leftHandInput.value === '';
     const rightEmpty = rightHandInput.value === '';
     mirrorBtn.style.display = (leftEmpty !== rightEmpty) ? 'inline-block' : 'none';
+    updateEquipButtons();
 }
 
 function editHand(handId) {
     editTarget = document.getElementById(handId);
     document.getElementById('popupPrompt').textContent = `Choose equipment for your ${handId.replace('Hand', '')} hand:`;
     equipmentPopup.style.display = 'block';
+}
+
+function handleEquipButton(handId) {
+    const input = document.getElementById(handId);
+    if (inCombat && input.value) {
+        if (input.value === 'shield') {
+            if (actions > 0) {
+                actions -= 1;
+                updateCounts();
+            } else {
+                alert('No actions left to unequip a shield.');
+                return;
+            }
+        }
+        input.value = '';
+        checkHands();
+    } else {
+        editHand(handId);
+    }
 }
 
 attackBtn.addEventListener('click', () => {
@@ -156,8 +189,8 @@ cancelPopup.addEventListener('click', () => {
     editTarget = null;
 });
 
-editLeftBtn.addEventListener('click', () => editHand('leftHand'));
-editRightBtn.addEventListener('click', () => editHand('rightHand'));
+editLeftBtn.addEventListener('click', () => handleEquipButton('leftHand'));
+editRightBtn.addEventListener('click', () => handleEquipButton('rightHand'));
 
 mirrorBtn.addEventListener('click', () => {
     if (leftHandInput.value && !rightHandInput.value) {


### PR DESCRIPTION
## Summary
- rename Edit buttons to Equip in the page
- add dynamic Equip/Unequip behavior in JavaScript
- update README to describe the updated controls

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848157723c48325a19bbbaf4dc9ec32